### PR TITLE
Attempt to load direct filesystem if the MBR partition table is empty

### DIFF
--- a/disk.go
+++ b/disk.go
@@ -13,7 +13,7 @@ import (
 func NewDriver(sr *io.SectionReader, checkFsFuncs ...fs.CheckFsFunc) (types.Driver, error) {
 	m, err := mbr.NewMasterBootRecord(sr)
 	if err != nil {
-		if xerrors.Is(mbr.InvalidSignature, err) {
+		if xerrors.Is(mbr.EmptyPartitionTable, err) || xerrors.Is(mbr.InvalidSignature, err) {
 			ok, err := fs.CheckFileSystems(sr, checkFsFuncs)
 			if err != nil {
 				return nil, xerrors.Errorf("failed to check filesystem: %w", err)

--- a/mbr/mbr.go
+++ b/mbr/mbr.go
@@ -49,6 +49,7 @@ Master Boot Record always 512 bytes.
 ref: https://www.ijais.org/research/volume10/number8/sadi-2016-ijais-451541.pdf
 */
 
+var EmptyPartitionTable = xerrors.New("All partitions in the master boot record are empty")
 var InvalidSignature = xerrors.New("Invalid master boot record signature")
 
 type MasterBootRecord struct {
@@ -183,7 +184,12 @@ func NewMasterBootRecord(sr *io.SectionReader) (*MasterBootRecord, error) {
 		return nil, InvalidSignature
 	}
 
+	emptyPartitions := 0
 	for i := 0; i < len(mbr.Partitions); i++ {
+		if mbr.Partitions[i].Type == 0 {
+			emptyPartitions++
+			continue
+		}
 		if mbr.Partitions[i].Type != 0x05 && mbr.Partitions[i].Type != 0x0f {
 			continue
 		}
@@ -200,6 +206,11 @@ func NewMasterBootRecord(sr *io.SectionReader) (*MasterBootRecord, error) {
 			return nil, xerrors.New("unsupported extended master boot record")
 		}
 	}
+
+	if emptyPartitions == len(mbr.Partitions) {
+		return nil, EmptyPartitionTable
+	}
+
 	return &mbr, nil
 }
 


### PR DESCRIPTION
We have a handful of volumes that are direct ext4 volumes and use grub to boot. It appears that when grub installs into a non-partitioned volume, it creates a valid MBR with all partitions empty.

I confirmed that this will not conflict with the MBR that GPT creates as GPT necessitates having a [single protective partition](https://en.wikipedia.org/wiki/GUID_Partition_Table#PROTECTIVE-MBR) with type `0xEE` that encompasses the entire volume.