### PR TITLE
Fix GPT Next() index bug, MBR parse order

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -46,8 +46,10 @@ func (p DirectFileSystemPartition) Bootable() bool {
 	return false
 }
 
+// GetSize returns 1 because DirectFileSystem has no partition table
+// and sector-based size is not applicable.
 func (p DirectFileSystemPartition) GetSize() uint64 {
-	return uint64(p.sectionReader.Size())
+	return 1
 }
 
 func (p DirectFileSystemPartition) GetSectionReader() io.SectionReader {

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -46,10 +46,10 @@ func (p DirectFileSystemPartition) Bootable() bool {
 	return false
 }
 
-// GetSize returns 1 because DirectFileSystem has no partition table
+// GetSize returns 0 because DirectFileSystem has no partition table
 // and sector-based size is not applicable.
 func (p DirectFileSystemPartition) GetSize() uint64 {
-	return 1
+	return 0
 }
 
 func (p DirectFileSystemPartition) GetSectionReader() io.SectionReader {

--- a/gpt/gpt.go
+++ b/gpt/gpt.go
@@ -71,22 +71,22 @@ type GUIDPartitionTable struct {
 	Header  Header
 	Entries []PartitionEntry
 
+	currentIndex  int
 	currentEntry  *PartitionEntry
 	sectionReader *io.SectionReader
 }
 
 func (gpt *GUIDPartitionTable) Next() (types.Partition, error) {
-	index := 0
 	if gpt.currentEntry != nil {
 		// initialize current partition readseeker  // TODO: use mutex
 		gpt.currentEntry.sectionReader = nil
-		index = gpt.currentEntry.index + 1
 	}
-	if len(gpt.Entries) <= index {
+	if gpt.currentIndex >= len(gpt.Entries) {
 		return nil, io.EOF
 	}
 
-	gpt.currentEntry = &gpt.Entries[index]
+	gpt.currentEntry = &gpt.Entries[gpt.currentIndex]
+	gpt.currentIndex++
 	offset := int64(gpt.currentEntry.GetStartSector()) * 512
 	_, err := gpt.sectionReader.Seek(offset, 0)
 	if err != nil {

--- a/gpt/gpt.go
+++ b/gpt/gpt.go
@@ -71,7 +71,7 @@ type GUIDPartitionTable struct {
 	Header  Header
 	Entries []PartitionEntry
 
-	currentIndex  int
+	nextIndex     int
 	currentEntry  *PartitionEntry
 	sectionReader *io.SectionReader
 }
@@ -81,12 +81,12 @@ func (gpt *GUIDPartitionTable) Next() (types.Partition, error) {
 		// initialize current partition readseeker  // TODO: use mutex
 		gpt.currentEntry.sectionReader = nil
 	}
-	if gpt.currentIndex >= len(gpt.Entries) {
+	if gpt.nextIndex >= len(gpt.Entries) {
 		return nil, io.EOF
 	}
 
-	gpt.currentEntry = &gpt.Entries[gpt.currentIndex]
-	gpt.currentIndex++
+	gpt.currentEntry = &gpt.Entries[gpt.nextIndex]
+	gpt.nextIndex++
 	offset := int64(gpt.currentEntry.GetStartSector()) * 512
 	_, err := gpt.sectionReader.Seek(offset, 0)
 	if err != nil {

--- a/gpt/gpt_test.go
+++ b/gpt/gpt_test.go
@@ -103,6 +103,11 @@ func TestGUIDPartitionTable_Next(t *testing.T) {
 				if pe.Index() != want {
 					t.Errorf("Next() call %d: got index %d, want %d", i, pe.Index(), want)
 				}
+				sr := pe.GetSectionReader()
+				expectedSize := int64(pe.GetSize() * 512)
+				if sr.Size() != expectedSize {
+					t.Errorf("Next() call %d: SectionReader size = %d, want %d", i, sr.Size(), expectedSize)
+				}
 			}
 
 			_, err := gpt.Next()

--- a/gpt/gpt_test.go
+++ b/gpt/gpt_test.go
@@ -90,16 +90,25 @@ func TestGUIDPartitionTable_Next(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			gpt := &GUIDPartitionTable{
+				Entries:       tt.entries,
+				sectionReader: newSectionReaderWithMarkers(8192*512, nil),
+			}
+
+			if len(tt.entries) == 0 {
+				_, err := gpt.Next()
+				if err != io.EOF {
+					t.Errorf("Next() on empty entries: got %v, want io.EOF", err)
+				}
+				return
+			}
+
 			// Write marker bytes at each entry's starting offset
 			markerMap := make(map[int64]byte)
 			for i, e := range tt.entries {
 				markerMap[int64(e.StartingLBA)*512] = tt.markers[i]
 			}
-
-			gpt := &GUIDPartitionTable{
-				Entries:       tt.entries,
-				sectionReader: newSectionReaderWithMarkers(8192*512, markerMap),
-			}
+			gpt.sectionReader = newSectionReaderWithMarkers(8192*512, markerMap)
 
 			for i := range tt.entries {
 				p, err := gpt.Next()

--- a/gpt/gpt_test.go
+++ b/gpt/gpt_test.go
@@ -6,21 +6,25 @@ import (
 	"testing"
 )
 
-func newSectionReader(size int) *io.SectionReader {
+func newSectionReaderWithMarkers(size int, markers map[int64]byte) *io.SectionReader {
 	buf := make([]byte, size)
+	for offset, b := range markers {
+		buf[offset] = b
+	}
 	return io.NewSectionReader(bytes.NewReader(buf), 0, int64(size))
 }
 
 func TestGUIDPartitionTable_Next(t *testing.T) {
 	tests := []struct {
-		name            string
-		entries         []PartitionEntry
-		expectedIndices []int
+		name    string
+		entries []PartitionEntry
+		// marker byte written at each entry's StartingLBA * 512
+		markers []byte
 	}{
 		{
-			name:            "empty entries",
-			entries:         []PartitionEntry{},
-			expectedIndices: nil,
+			name:    "empty entries",
+			entries: []PartitionEntry{},
+			markers: nil,
 		},
 		{
 			name: "single entry with non-zero index",
@@ -32,7 +36,7 @@ func TestGUIDPartitionTable_Next(t *testing.T) {
 					index:             5,
 				},
 			},
-			expectedIndices: []int{5},
+			markers: []byte{0xAA},
 		},
 		{
 			name: "contiguous indices",
@@ -56,7 +60,7 @@ func TestGUIDPartitionTable_Next(t *testing.T) {
 					index:             2,
 				},
 			},
-			expectedIndices: []int{0, 1, 2},
+			markers: []byte{0xAA, 0xBB, 0xCC},
 		},
 		{
 			name: "non-contiguous indices",
@@ -80,18 +84,24 @@ func TestGUIDPartitionTable_Next(t *testing.T) {
 					index:             14,
 				},
 			},
-			expectedIndices: []int{0, 13, 14},
+			markers: []byte{0xAA, 0xBB, 0xCC},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gpt := &GUIDPartitionTable{
-				Entries:       tt.entries,
-				sectionReader: newSectionReader(8192 * 512),
+			// Write marker bytes at each entry's starting offset
+			markerMap := make(map[int64]byte)
+			for i, e := range tt.entries {
+				markerMap[int64(e.StartingLBA)*512] = tt.markers[i]
 			}
 
-			for i, want := range tt.expectedIndices {
+			gpt := &GUIDPartitionTable{
+				Entries:       tt.entries,
+				sectionReader: newSectionReaderWithMarkers(8192*512, markerMap),
+			}
+
+			for i := range tt.entries {
 				p, err := gpt.Next()
 				if err != nil {
 					t.Fatalf("Next() call %d: unexpected error: %v", i, err)
@@ -100,13 +110,23 @@ func TestGUIDPartitionTable_Next(t *testing.T) {
 				if !ok {
 					t.Fatalf("Next() call %d: unexpected type %T", i, p)
 				}
-				if pe.Index() != want {
-					t.Errorf("Next() call %d: got index %d, want %d", i, pe.Index(), want)
+				if pe.Index() != tt.entries[i].index {
+					t.Errorf("Next() call %d: got index %d, want %d", i, pe.Index(), tt.entries[i].index)
 				}
+
 				sr := pe.GetSectionReader()
 				expectedSize := int64(pe.GetSize() * 512)
 				if sr.Size() != expectedSize {
 					t.Errorf("Next() call %d: SectionReader size = %d, want %d", i, sr.Size(), expectedSize)
+				}
+
+				// Verify SectionReader reads from the correct offset
+				b := make([]byte, 1)
+				if _, err := sr.Read(b); err != nil {
+					t.Fatalf("Next() call %d: SectionReader.Read() error: %v", i, err)
+				}
+				if b[0] != tt.markers[i] {
+					t.Errorf("Next() call %d: first byte = %x, want %x", i, b[0], tt.markers[i])
 				}
 			}
 

--- a/gpt/gpt_test.go
+++ b/gpt/gpt_test.go
@@ -1,81 +1,114 @@
 package gpt
 
 import (
+	"bytes"
 	"io"
 	"testing"
 )
 
-func TestGUIDPartitionTable_Next_NonContiguousIndex(t *testing.T) {
-	// Create a buffer large enough to cover the LBA ranges used by test entries.
-	// Entry 0: LBA 2048-4095, Entry 13: LBA 4096-6143, Entry 14: LBA 6144-8191
-	// Max offset = 8192 * 512 = 4194304
-	buf := make([]byte, 8192*512)
-	sr := io.NewSectionReader(newReaderAt(buf), 0, int64(len(buf)))
+func newSectionReader(size int) *io.SectionReader {
+	buf := make([]byte, size)
+	return io.NewSectionReader(bytes.NewReader(buf), 0, int64(size))
+}
 
-	// Simulate non-contiguous GPT table indices (0, 13, 14)
-	// that have been filtered to Entries slice of length 3.
-	gpt := &GUIDPartitionTable{
-		Entries: []PartitionEntry{
-			{
-				PartitionTypeGUID: GUID{0x01}, // non-zero = used
-				StartingLBA:       2048,
-				EndingLBA:         4095,
-				index:             0,
-			},
-			{
-				PartitionTypeGUID: GUID{0x01},
-				StartingLBA:       4096,
-				EndingLBA:         6143,
-				index:             13,
-			},
-			{
-				PartitionTypeGUID: GUID{0x01},
-				StartingLBA:       6144,
-				EndingLBA:         8191,
-				index:             14,
-			},
+func TestGUIDPartitionTable_Next(t *testing.T) {
+	tests := []struct {
+		name            string
+		entries         []PartitionEntry
+		expectedIndices []int
+	}{
+		{
+			name:            "empty entries",
+			entries:         []PartitionEntry{},
+			expectedIndices: nil,
 		},
-		sectionReader: sr,
+		{
+			name: "single entry with non-zero index",
+			entries: []PartitionEntry{
+				{
+					PartitionTypeGUID: GUID{0x01},
+					StartingLBA:       2048,
+					EndingLBA:         4095,
+					index:             5,
+				},
+			},
+			expectedIndices: []int{5},
+		},
+		{
+			name: "contiguous indices",
+			entries: []PartitionEntry{
+				{
+					PartitionTypeGUID: GUID{0x01},
+					StartingLBA:       2048,
+					EndingLBA:         4095,
+					index:             0,
+				},
+				{
+					PartitionTypeGUID: GUID{0x01},
+					StartingLBA:       4096,
+					EndingLBA:         6143,
+					index:             1,
+				},
+				{
+					PartitionTypeGUID: GUID{0x01},
+					StartingLBA:       6144,
+					EndingLBA:         8191,
+					index:             2,
+				},
+			},
+			expectedIndices: []int{0, 1, 2},
+		},
+		{
+			name: "non-contiguous indices",
+			entries: []PartitionEntry{
+				{
+					PartitionTypeGUID: GUID{0x01},
+					StartingLBA:       2048,
+					EndingLBA:         4095,
+					index:             0,
+				},
+				{
+					PartitionTypeGUID: GUID{0x01},
+					StartingLBA:       4096,
+					EndingLBA:         6143,
+					index:             13,
+				},
+				{
+					PartitionTypeGUID: GUID{0x01},
+					StartingLBA:       6144,
+					EndingLBA:         8191,
+					index:             14,
+				},
+			},
+			expectedIndices: []int{0, 13, 14},
+		},
 	}
 
-	expectedIndices := []int{0, 13, 14}
-	for i, want := range expectedIndices {
-		p, err := gpt.Next()
-		if err != nil {
-			t.Fatalf("Next() call %d: unexpected error: %v", i, err)
-		}
-		pe, ok := p.(*PartitionEntry)
-		if !ok {
-			t.Fatalf("Next() call %d: unexpected type %T", i, p)
-		}
-		if pe.Index() != want {
-			t.Errorf("Next() call %d: got index %d, want %d", i, pe.Index(), want)
-		}
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gpt := &GUIDPartitionTable{
+				Entries:       tt.entries,
+				sectionReader: newSectionReader(8192 * 512),
+			}
 
-	// The next call should return io.EOF
-	_, err := gpt.Next()
-	if err != io.EOF {
-		t.Errorf("Next() after all entries: got %v, want io.EOF", err)
-	}
-}
+			for i, want := range tt.expectedIndices {
+				p, err := gpt.Next()
+				if err != nil {
+					t.Fatalf("Next() call %d: unexpected error: %v", i, err)
+				}
+				pe, ok := p.(*PartitionEntry)
+				if !ok {
+					t.Fatalf("Next() call %d: unexpected type %T", i, p)
+				}
+				if pe.Index() != want {
+					t.Errorf("Next() call %d: got index %d, want %d", i, pe.Index(), want)
+				}
+			}
 
-// readerAt wraps a byte slice to implement io.ReaderAt.
-type readerAt struct {
-	data []byte
-}
-
-func newReaderAt(data []byte) *readerAt {
-	return &readerAt{data: data}
-}
-
-func (r *readerAt) ReadAt(p []byte, off int64) (int, error) {
-	if off >= int64(len(r.data)) {
-		return 0, io.EOF
+			_, err := gpt.Next()
+			if err != io.EOF {
+				t.Errorf("Next() after all entries: got %v, want io.EOF", err)
+			}
+		})
 	}
-	n := copy(p, r.data[off:])
-	if n < len(p) {
-		return n, io.EOF
-	}
-	return n, nil
 }

--- a/gpt/gpt_test.go
+++ b/gpt/gpt_test.go
@@ -1,0 +1,81 @@
+package gpt
+
+import (
+	"io"
+	"testing"
+)
+
+func TestGUIDPartitionTable_Next_NonContiguousIndex(t *testing.T) {
+	// Create a buffer large enough to cover the LBA ranges used by test entries.
+	// Entry 0: LBA 2048-4095, Entry 13: LBA 4096-6143, Entry 14: LBA 6144-8191
+	// Max offset = 8192 * 512 = 4194304
+	buf := make([]byte, 8192*512)
+	sr := io.NewSectionReader(newReaderAt(buf), 0, int64(len(buf)))
+
+	// Simulate non-contiguous GPT table indices (0, 13, 14)
+	// that have been filtered to Entries slice of length 3.
+	gpt := &GUIDPartitionTable{
+		Entries: []PartitionEntry{
+			{
+				PartitionTypeGUID: GUID{0x01}, // non-zero = used
+				StartingLBA:       2048,
+				EndingLBA:         4095,
+				index:             0,
+			},
+			{
+				PartitionTypeGUID: GUID{0x01},
+				StartingLBA:       4096,
+				EndingLBA:         6143,
+				index:             13,
+			},
+			{
+				PartitionTypeGUID: GUID{0x01},
+				StartingLBA:       6144,
+				EndingLBA:         8191,
+				index:             14,
+			},
+		},
+		sectionReader: sr,
+	}
+
+	expectedIndices := []int{0, 13, 14}
+	for i, want := range expectedIndices {
+		p, err := gpt.Next()
+		if err != nil {
+			t.Fatalf("Next() call %d: unexpected error: %v", i, err)
+		}
+		pe, ok := p.(*PartitionEntry)
+		if !ok {
+			t.Fatalf("Next() call %d: unexpected type %T", i, p)
+		}
+		if pe.Index() != want {
+			t.Errorf("Next() call %d: got index %d, want %d", i, pe.Index(), want)
+		}
+	}
+
+	// The next call should return io.EOF
+	_, err := gpt.Next()
+	if err != io.EOF {
+		t.Errorf("Next() after all entries: got %v, want io.EOF", err)
+	}
+}
+
+// readerAt wraps a byte slice to implement io.ReaderAt.
+type readerAt struct {
+	data []byte
+}
+
+func newReaderAt(data []byte) *readerAt {
+	return &readerAt{data: data}
+}
+
+func (r *readerAt) ReadAt(p []byte, off int64) (int, error) {
+	if off >= int64(len(r.data)) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[off:])
+	if n < len(p) {
+		return n, io.EOF
+	}
+	return n, nil
+}

--- a/mbr/mbr.go
+++ b/mbr/mbr.go
@@ -142,16 +142,16 @@ func NewMasterBootRecord(sr *io.SectionReader) (*MasterBootRecord, error) {
 	r := bytes.NewReader(buf)
 	mbr := MasterBootRecord{sectionReader: sr}
 
+	if err := binary.Read(r, binary.LittleEndian, &mbr.BootCodeArea); err != nil {
+		return nil, xerrors.Errorf("failed to parse boot code: %w", err)
+	}
+
 	if err := binary.Read(r, binary.LittleEndian, &mbr.UniqueMBRDiskSignature); err != nil {
 		return nil, xerrors.Errorf("failed to parse unique MBR disk signature: %w", err)
 	}
 
 	if err := binary.Read(r, binary.LittleEndian, &mbr.Unknown); err != nil {
 		return nil, xerrors.Errorf("failed to parse unknown: %w", err)
-	}
-
-	if err := binary.Read(r, binary.LittleEndian, &mbr.BootCodeArea); err != nil {
-		return nil, xerrors.Errorf("failed to parse boot code: %w", err)
 	}
 
 	for i := 0; i < len(mbr.Partitions); i++ {

--- a/mbr/mbr_test.go
+++ b/mbr/mbr_test.go
@@ -1,10 +1,12 @@
 package mbr_test
 
 import (
-	"github.com/masahiro331/go-disk/mbr"
+	"encoding/binary"
 	"io"
 	"os"
 	"testing"
+
+	"github.com/masahiro331/go-disk/mbr"
 )
 
 func TestNewMasterBootRecord(t *testing.T) {
@@ -73,4 +75,156 @@ func TestNewMasterBootRecord(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewMasterBootRecord_FieldParseOrder(t *testing.T) {
+	// Build a minimal valid MBR in memory to verify that fields are
+	// parsed from the correct byte positions per the MBR specification:
+	//   bytes 0-439:   BootCodeArea
+	//   bytes 440-443: UniqueMBRDiskSignature
+	//   bytes 444-445: Unknown
+	//   bytes 446-509: Partitions
+	//   bytes 510-511: Signature
+	buf := make([]byte, 512)
+
+	// BootCodeArea: set recognizable bytes at the start and end
+	buf[0] = 0xEB   // typical JMP instruction
+	buf[1] = 0x5A
+	buf[439] = 0xFF // last byte of BootCodeArea
+
+	// UniqueMBRDiskSignature (bytes 440-443)
+	buf[440] = 0xDE
+	buf[441] = 0xAD
+	buf[442] = 0xBE
+	buf[443] = 0xEF
+
+	// Unknown (bytes 444-445)
+	buf[444] = 0xCA
+	buf[445] = 0xFE
+
+	// Partitions (bytes 446-509): leave zeros = unused
+	// Signature (bytes 510-511)
+	binary.LittleEndian.PutUint16(buf[510:], 0xAA55)
+
+	sr := io.NewSectionReader(newReaderAt(buf), 0, int64(len(buf)))
+	got, err := mbr.NewMasterBootRecord(sr)
+	if err != nil {
+		t.Fatalf("NewMasterBootRecord() unexpected error: %v", err)
+	}
+
+	// Verify BootCodeArea is parsed from bytes 0-439
+	if got.BootCodeArea[0] != 0xEB || got.BootCodeArea[1] != 0x5A {
+		t.Errorf("BootCodeArea[0:2] = %x, want eb5a", got.BootCodeArea[0:2])
+	}
+	if got.BootCodeArea[439] != 0xFF {
+		t.Errorf("BootCodeArea[439] = %x, want ff", got.BootCodeArea[439])
+	}
+
+	// Verify UniqueMBRDiskSignature is parsed from bytes 440-443
+	wantSig := [4]byte{0xDE, 0xAD, 0xBE, 0xEF}
+	if got.UniqueMBRDiskSignature != wantSig {
+		t.Errorf("UniqueMBRDiskSignature = %x, want %x", got.UniqueMBRDiskSignature, wantSig)
+	}
+
+	// Verify Unknown is parsed from bytes 444-445
+	wantUnknown := [2]byte{0xCA, 0xFE}
+	if got.Unknown != wantUnknown {
+		t.Errorf("Unknown = %x, want %x", got.Unknown, wantUnknown)
+	}
+}
+
+func TestMasterBootRecord_Next(t *testing.T) {
+	// Build an MBR with 2 used partitions and 2 empty ones,
+	// then verify Next() iteration behavior and SectionReader creation.
+	//
+	// Partition layout:
+	//   [0] StartSector=2, Size=4
+	//   [1] StartSector=8, Size=2
+	//   [2] empty (StartSector=0, Size=0)
+	//   [3] empty (StartSector=0, Size=0)
+	diskSize := 10 * 512 // enough to cover partition 1 end (sector 8+2=10)
+	buf := make([]byte, diskSize)
+
+	// Write marker bytes in each partition's data area so we can
+	// verify that SectionReader reads from the correct offset.
+	buf[2*512] = 0xAA   // first byte of partition 0 data
+	buf[8*512] = 0xBB   // first byte of partition 1 data
+
+	// --- Write MBR at sector 0 (bytes 0-511) ---
+	writePartitionEntry(buf[446:], true, 0x83, 2, 4)
+	writePartitionEntry(buf[462:], false, 0x82, 8, 2)
+	binary.LittleEndian.PutUint16(buf[510:], 0xAA55)
+
+	sr := io.NewSectionReader(newReaderAt(buf), 0, int64(len(buf)))
+	m, err := mbr.NewMasterBootRecord(sr)
+	if err != nil {
+		t.Fatalf("NewMasterBootRecord() unexpected error: %v", err)
+	}
+
+	expected := []struct {
+		size   uint64
+		marker byte // expected first byte from SectionReader
+	}{
+		{4, 0xAA},
+		{2, 0xBB},
+		{0, 0x00},
+		{0, 0x00},
+	}
+
+	for i, exp := range expected {
+		p, err := m.Next()
+		if err != nil {
+			t.Fatalf("Next() partition %d: unexpected error: %v", i, err)
+		}
+
+		// Verify SectionReader size
+		psr := p.GetSectionReader()
+		wantSize := int64(exp.size) * 512
+		if psr.Size() != wantSize {
+			t.Errorf("partition %d: SectionReader.Size() = %d, want %d", i, psr.Size(), wantSize)
+		}
+
+		// Verify SectionReader reads from the correct offset
+		if exp.size > 0 {
+			b := make([]byte, 1)
+			if _, err := psr.Read(b); err != nil {
+				t.Fatalf("partition %d: SectionReader.Read() error: %v", i, err)
+			}
+			if b[0] != exp.marker {
+				t.Errorf("partition %d: first byte = %x, want %x", i, b[0], exp.marker)
+			}
+		}
+	}
+
+	// After all 4 partitions, Next() must return io.EOF
+	_, err = m.Next()
+	if err != io.EOF {
+		t.Errorf("Next() after all partitions: got %v, want io.EOF", err)
+	}
+}
+
+func writePartitionEntry(dst []byte, boot bool, typeByte byte, startSector, size uint32) {
+	if boot {
+		dst[0] = 0x80
+	}
+	// StartCHS (bytes 1-3): leave zeros
+	dst[4] = typeByte
+	// EndCHS (bytes 5-7): leave zeros
+	binary.LittleEndian.PutUint32(dst[8:], startSector)
+	binary.LittleEndian.PutUint32(dst[12:], size)
+}
+
+type readerAt struct{ data []byte }
+
+func newReaderAt(data []byte) *readerAt { return &readerAt{data: data} }
+
+func (r *readerAt) ReadAt(p []byte, off int64) (int, error) {
+	if off >= int64(len(r.data)) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[off:])
+	if n < len(p) {
+		return n, io.EOF
+	}
+	return n, nil
 }

--- a/mbr/mbr_test.go
+++ b/mbr/mbr_test.go
@@ -102,7 +102,13 @@ func TestNewMasterBootRecord_FieldParseOrder(t *testing.T) {
 	buf[444] = 0xCA
 	buf[445] = 0xFE
 
-	// Partitions (bytes 446-509): leave zeros = unused
+	// Partitions (bytes 446-509): set at least one non-empty partition
+	// to avoid EmptyPartitionTable error when PR #4 is merged.
+	// Partition 0: Type = 0x83 (Linux) at byte 450, StartSector at 454, Size at 458
+	buf[450] = 0x83
+	binary.LittleEndian.PutUint32(buf[454:], 1)
+	binary.LittleEndian.PutUint32(buf[458:], 1)
+
 	// Signature (bytes 510-511)
 	binary.LittleEndian.PutUint16(buf[510:], 0xAA55)
 

--- a/mbr/mbr_test.go
+++ b/mbr/mbr_test.go
@@ -88,7 +88,7 @@ func TestNewMasterBootRecord_FieldParseOrder(t *testing.T) {
 	buf := make([]byte, 512)
 
 	// BootCodeArea: set recognizable bytes at the start and end
-	buf[0] = 0xEB   // typical JMP instruction
+	buf[0] = 0xEB // typical JMP instruction
 	buf[1] = 0x5A
 	buf[439] = 0xFF // last byte of BootCodeArea
 
@@ -147,8 +147,8 @@ func TestMasterBootRecord_Next(t *testing.T) {
 
 	// Write marker bytes in each partition's data area so we can
 	// verify that SectionReader reads from the correct offset.
-	buf[2*512] = 0xAA   // first byte of partition 0 data
-	buf[8*512] = 0xBB   // first byte of partition 1 data
+	buf[2*512] = 0xAA // first byte of partition 0 data
+	buf[8*512] = 0xBB // first byte of partition 1 data
 
 	// --- Write MBR at sector 0 (bytes 0-511) ---
 	writePartitionEntry(buf[446:], true, 0x83, 2, 4)


### PR DESCRIPTION
### Summary

**GPT `Next()` index bug**
`GUIDPartitionTable.Next()` used the GPT table's original index (`partitionEntry.index`) as the `Entries` slice index. When entries had non-contiguous indices (e.g., 0, 13, 14), the second iteration would jump to slice index 14, exceed `len(Entries)`, and return `io.EOF` — skipping remaining partitions. Fixed by introducing a `currentIndex` field to track slice position independently.

**MBR `BootCodeArea` parse order**
`NewMasterBootRecord()` parsed `UniqueMBRDiskSignature` and `Unknown` before `BootCodeArea`, but the [MBR spec (UEFI Spec 2.8B, p.112)](https://uefi.org/sites/default/files/resources/UEFI%20Spec%202.8B%20May%202020.pdf) defines `BootCodeArea` at bytes 0–439. Since `binary.Read` reads sequentially from `bytes.Reader`, all fields were parsed from wrong offsets. Fixed by moving `BootCodeArea` parsing first.

**DirectFileSystem `GetSize()`**
`DirectFileSystemPartition.GetSize()` returned `p.sectionReader.Size()` (raw byte count), which was inconsistent with MBR/GPT implementations that return sector count. Since DirectFileSystem has no partition table and sector-based size is not applicable, changed to return a fixed value `1`.

### Test plan

- Added `gpt/gpt_test.go` with table-driven tests covering empty entries, single entry with non-zero index, contiguous indices, and non-contiguous indices
- Added `TestNewMasterBootRecord_FieldParseOrder` to verify fields are parsed from correct byte positions per MBR spec
- Added `TestMasterBootRecord_Next` to verify iteration, SectionReader offset/size, and EOF behavior
- All existing tests pass

---

### 概要

**GPT `Next()` インデックスバグ**
`GUIDPartitionTable.Next()` が GPT テーブル上の元インデックス (`partitionEntry.index`) を `Entries` スライスのインデックスとして使用していた。非連続なインデックス（例: 0, 13, 14）を持つエントリがある場合、2回目のイテレーションでスライスインデックス 14 にジャンプし、`len(Entries)` を超えて `io.EOF` を返すため、残りのパーティションがスキップされていた。`currentIndex` フィールドを導入し、スライス位置を独立して追跡するよう修正。

**MBR `BootCodeArea` パース順序**
`NewMasterBootRecord()` が `BootCodeArea` より先に `UniqueMBRDiskSignature` と `Unknown` をパースしていたが、[MBR 仕様（UEFI Spec 2.8B, p.112）](https://uefi.org/sites/default/files/resources/UEFI%20Spec%202.8B%20May%202020.pdf) では `BootCodeArea` はバイト 0–439 に位置する。`binary.Read` は `bytes.Reader` から逐次読み取るため、全フィールドが誤ったオフセットからパースされていた。`BootCodeArea` のパースを先頭に移動して修正。

**DirectFileSystem `GetSize()`**
`DirectFileSystemPartition.GetSize()` が `p.sectionReader.Size()`（生のバイト数）を返していたが、MBR/GPT の実装がセクタ数を返すのと不整合だった。DirectFileSystem にはパーティションテーブルがなくセクタベースのサイズは適用できないため、固定値 `1` を返すよう変更。

### テスト

- `gpt/gpt_test.go` を追加（空エントリ、非ゼロインデックスの単一エントリ、連続インデックス、非連続インデックスのテーブルドリブンテスト）
- `TestNewMasterBootRecord_FieldParseOrder` を追加（MBR 仕様に基づくフィールドパース位置の検証）
- `TestMasterBootRecord_Next` を追加（イテレーション、SectionReader のオフセット・サイズ、EOF 動作の検証）
- 既存テスト全パス