### PR TITLE
Fix xerrors.Is argument order

### DIFF
--- a/disk.go
+++ b/disk.go
@@ -13,7 +13,7 @@ import (
 func NewDriver(sr *io.SectionReader, checkFsFuncs ...fs.CheckFsFunc) (types.Driver, error) {
 	m, err := mbr.NewMasterBootRecord(sr)
 	if err != nil {
-		if xerrors.Is(mbr.EmptyPartitionTable, err) || xerrors.Is(mbr.InvalidSignature, err) {
+		if xerrors.Is(err, mbr.EmptyPartitionTable) || xerrors.Is(err, mbr.InvalidSignature) {
 			ok, err := fs.CheckFileSystems(sr, checkFsFuncs)
 			if err != nil {
 				return nil, xerrors.Errorf("failed to check filesystem: %w", err)

--- a/mbr/mbr.go
+++ b/mbr/mbr.go
@@ -198,7 +198,7 @@ func NewMasterBootRecord(sr *io.SectionReader) (*MasterBootRecord, error) {
 			return nil, xerrors.Errorf("failed to seek to extended boot record: %w", err)
 		}
 		_, err = NewMasterBootRecord(sr)
-		if xerrors.Is(InvalidSignature, err) {
+		if xerrors.Is(err, InvalidSignature) {
 			mbr.Partitions[i].StartSector = mbr.Partitions[i].StartSector + 2
 			mbr.Partitions[i].Size = mbr.Partitions[i].Size - 2
 		} else {


### PR DESCRIPTION
## Summary

Fix incorrect argument order in `xerrors.Is` calls. The function signature is `xerrors.Is(err, target)`, but the arguments were swapped in three call sites.

## Changes

- `disk.go`: Swap arguments in `xerrors.Is(mbr.EmptyPartitionTable, err)` and `xerrors.Is(mbr.InvalidSignature, err)`
- `mbr/mbr.go`: Swap arguments in `xerrors.Is(InvalidSignature, err)`

## Why

`xerrors.Is(err, target)` unwraps the first argument (`err`) and compares it against the second argument (`target`). With the reversed order, it unwraps the sentinel error instead of the error chain. This currently works by coincidence because the sentinel errors are returned without wrapping, but it will silently break if they are ever wrapped (e.g., `xerrors.Errorf("...: %w", InvalidSignature)`).

---

## 概要

`xerrors.Is` の引数順序が逆になっている箇所を修正します。関数シグネチャは `xerrors.Is(err, target)` ですが、3箇所で引数が入れ替わっていました。

## 変更内容

- `disk.go`: `xerrors.Is(mbr.EmptyPartitionTable, err)` と `xerrors.Is(mbr.InvalidSignature, err)` の引数順序を修正
- `mbr/mbr.go`: `xerrors.Is(InvalidSignature, err)` の引数順序を修正

## 理由

`xerrors.Is(err, target)` は第1引数 (`err`) をアンラップしながら第2引数 (`target`) と一致するか確認します。引数が逆の場合、エラーチェーンではなくセンチネルエラー側をアンラップしてしまいます。現在はセンチネルエラーがラップされずに返されるため偶然動作していますが、将来ラップされた場合（例: `xerrors.Errorf("...: %w", InvalidSignature)`）にマッチしなくなります。