### PR TITLE
Add extended boot record (EBR) chain traversal

### DIFF
--- a/mbr/mbr.go
+++ b/mbr/mbr.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	SIGNATURE = 0xAA55
-	Sector    = 512
+	SIGNATURE        = 0xAA55
+	Sector           = 512
+	maxEBRChainDepth = 256
 )
 
 /*
@@ -59,8 +60,10 @@ type MasterBootRecord struct {
 	Partitions             [4]Partition
 	Signature              uint16
 
-	currentPartition *Partition
-	sectionReader    *io.SectionReader
+	logicalPartitions []Partition
+	currentIndex      int
+	currentPartition  *Partition
+	sectionReader     *io.SectionReader
 }
 
 type CHS [3]byte
@@ -80,24 +83,32 @@ type Partition struct {
 }
 
 func (m *MasterBootRecord) Next() (types.Partition, error) {
-	index := 0
 	if m.currentPartition != nil {
 		m.currentPartition.sectionReader = nil
-		index = m.currentPartition.index + 1
 	}
-	if len(m.Partitions) <= index {
+
+	total := len(m.Partitions) + len(m.logicalPartitions)
+	if m.currentIndex >= total {
 		return nil, io.EOF
 	}
 
-	m.currentPartition = &m.Partitions[index]
-	offset := int64(m.currentPartition.GetStartSector()) * 512
+	var p *Partition
+	if m.currentIndex < len(m.Partitions) {
+		p = &m.Partitions[m.currentIndex]
+	} else {
+		p = &m.logicalPartitions[m.currentIndex-len(m.Partitions)]
+	}
+	m.currentIndex++
+
+	offset := int64(p.GetStartSector()) * 512
 	_, err := m.sectionReader.Seek(offset, 0)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to seek partition(%d): %w", m.currentPartition.Index(), err)
+		return nil, xerrors.Errorf("failed to seek partition(%d): %w", p.Index(), err)
 	}
-	m.currentPartition.sectionReader = io.NewSectionReader(m.sectionReader, offset, int64(m.currentPartition.GetSize()*512))
+	p.sectionReader = io.NewSectionReader(m.sectionReader, offset, int64(p.GetSize()*512))
 
-	return m.currentPartition, nil
+	m.currentPartition = p
+	return p, nil
 }
 
 func (p Partition) Index() int {
@@ -193,18 +204,24 @@ func NewMasterBootRecord(sr *io.SectionReader) (*MasterBootRecord, error) {
 		if mbr.Partitions[i].Type != 0x05 && mbr.Partitions[i].Type != 0x0f {
 			continue
 		}
-		_, err := sr.Seek(int64(mbr.Partitions[i].StartSector)<<9, 0)
+		logicals, err := parseEBRChain(sr, mbr.Partitions[i].StartSector)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to seek to extended boot record: %w", err)
+			return nil, xerrors.Errorf("failed to parse extended partition: %w", err)
 		}
-		_, err = NewMasterBootRecord(sr)
-		if xerrors.Is(err, InvalidSignature) {
-			mbr.Partitions[i].StartSector = mbr.Partitions[i].StartSector + 2
-			mbr.Partitions[i].Size = mbr.Partitions[i].Size - 2
+		if len(logicals) > 0 {
+			mbr.logicalPartitions = append(mbr.logicalPartitions, logicals...)
 		} else {
-			// TODO: Support Extended Master Boot Record
-			return nil, xerrors.New("unsupported extended master boot record")
+			// No valid EBR found; adjust partition to skip past the EBR area.
+			mbr.Partitions[i].StartSector += 2
+			if mbr.Partitions[i].Size >= 2 {
+				mbr.Partitions[i].Size -= 2
+			}
 		}
+	}
+
+	// Assign indices to logical partitions (starting at 4)
+	for i := range mbr.logicalPartitions {
+		mbr.logicalPartitions[i].index = len(mbr.Partitions) + i
 	}
 
 	if emptyPartitions == len(mbr.Partitions) {
@@ -216,4 +233,66 @@ func NewMasterBootRecord(sr *io.SectionReader) (*MasterBootRecord, error) {
 
 func (p Partition) IsSupported() bool {
 	return true
+}
+
+func parsePartitionEntry(buf []byte) Partition {
+	return Partition{
+		Boot:        buf[0] != 0,
+		StartCHS:    CHS{buf[1], buf[2], buf[3]},
+		Type:        buf[4],
+		EndCHS:      CHS{buf[5], buf[6], buf[7]},
+		StartSector: binary.LittleEndian.Uint32(buf[8:12]),
+		Size:        binary.LittleEndian.Uint32(buf[12:16]),
+	}
+}
+
+// parseEBRChain traverses the Extended Boot Record chain starting at
+// extStartSector and returns all logical partitions found.
+// Each EBR has the same 512-byte structure as an MBR:
+//   - Entry 0: logical partition (StartSector relative to this EBR)
+//   - Entry 1: next EBR pointer (StartSector relative to extStartSector)
+func parseEBRChain(sr *io.SectionReader, extStartSector uint32) ([]Partition, error) {
+	var partitions []Partition
+	ebrSector := extStartSector
+	visited := make(map[uint32]bool)
+
+	for len(partitions) < maxEBRChainDepth {
+		if visited[ebrSector] {
+			break
+		}
+		visited[ebrSector] = true
+
+		ebrOffset := int64(ebrSector) * Sector
+		_, err := sr.Seek(ebrOffset, 0)
+		if err != nil {
+			break
+		}
+
+		buf := make([]byte, Sector)
+		n, err := sr.Read(buf)
+		if err != nil || n != Sector {
+			break
+		}
+
+		sig := binary.LittleEndian.Uint16(buf[510:512])
+		if sig != SIGNATURE {
+			break
+		}
+
+		// Entry 0: logical partition (StartSector relative to this EBR)
+		entry0 := parsePartitionEntry(buf[446:462])
+		if entry0.Type != 0 {
+			entry0.StartSector += ebrSector
+			partitions = append(partitions, entry0)
+		}
+
+		// Entry 1: next EBR pointer (StartSector relative to extended partition start)
+		entry1 := parsePartitionEntry(buf[462:478])
+		if entry1.Type == 0 || entry1.StartSector == 0 {
+			break
+		}
+		ebrSector = extStartSector + entry1.StartSector
+	}
+
+	return partitions, nil
 }

--- a/mbr/mbr.go
+++ b/mbr/mbr.go
@@ -204,10 +204,7 @@ func NewMasterBootRecord(sr *io.SectionReader) (*MasterBootRecord, error) {
 		if mbr.Partitions[i].Type != 0x05 && mbr.Partitions[i].Type != 0x0f {
 			continue
 		}
-		logicals, err := parseEBRChain(sr, mbr.Partitions[i].StartSector)
-		if err != nil {
-			return nil, xerrors.Errorf("failed to parse extended partition: %w", err)
-		}
+		logicals := parseEBRChain(sr, mbr.Partitions[i].StartSector)
 		if len(logicals) > 0 {
 			mbr.logicalPartitions = append(mbr.logicalPartitions, logicals...)
 		} else {
@@ -256,7 +253,7 @@ func parsePartitionEntry(buf []byte) Partition {
 // Each EBR has the same 512-byte structure as an MBR:
 //   - Entry 0: logical partition (StartSector relative to this EBR)
 //   - Entry 1: next EBR pointer (StartSector relative to extStartSector)
-func parseEBRChain(sr *io.SectionReader, extStartSector uint32) ([]Partition, error) {
+func parseEBRChain(sr *io.SectionReader, extStartSector uint32) []Partition {
 	var partitions []Partition
 	ebrSector := extStartSector
 	visited := make(map[uint32]bool)
@@ -299,5 +296,5 @@ func parseEBRChain(sr *io.SectionReader, extStartSector uint32) ([]Partition, er
 		ebrSector = extStartSector + entry1.StartSector
 	}
 
-	return partitions, nil
+	return partitions
 }

--- a/mbr/mbr.go
+++ b/mbr/mbr.go
@@ -257,6 +257,7 @@ func parseEBRChain(sr *io.SectionReader, extStartSector uint32) []Partition {
 	var partitions []Partition
 	ebrSector := extStartSector
 	visited := make(map[uint32]bool)
+	buf := make([]byte, Sector)
 
 	for len(partitions) < maxEBRChainDepth {
 		if visited[ebrSector] {
@@ -270,7 +271,6 @@ func parseEBRChain(sr *io.SectionReader, extStartSector uint32) []Partition {
 			break
 		}
 
-		buf := make([]byte, Sector)
 		n, err := sr.Read(buf)
 		if err != nil || n != Sector {
 			break

--- a/mbr/mbr.go
+++ b/mbr/mbr.go
@@ -236,6 +236,9 @@ func (p Partition) IsSupported() bool {
 }
 
 func parsePartitionEntry(buf []byte) Partition {
+	if len(buf) < 16 {
+		return Partition{}
+	}
 	return Partition{
 		Boot:        buf[0] != 0,
 		StartCHS:    CHS{buf[1], buf[2], buf[3]},

--- a/mbr/mbr.go
+++ b/mbr/mbr.go
@@ -259,7 +259,7 @@ func parseEBRChain(sr *io.SectionReader, extStartSector uint32) []Partition {
 	visited := make(map[uint32]bool)
 	buf := make([]byte, Sector)
 
-	for len(partitions) < maxEBRChainDepth {
+	for hops := 0; hops < maxEBRChainDepth; hops++ {
 		if visited[ebrSector] {
 			break
 		}

--- a/mbr/mbr.go
+++ b/mbr/mbr.go
@@ -204,7 +204,10 @@ func NewMasterBootRecord(sr *io.SectionReader) (*MasterBootRecord, error) {
 		if mbr.Partitions[i].Type != 0x05 && mbr.Partitions[i].Type != 0x0f {
 			continue
 		}
-		logicals := parseEBRChain(sr, mbr.Partitions[i].StartSector)
+		logicals, err := parseEBRChain(sr, mbr.Partitions[i].StartSector)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to parse extended partition %d: %w", i, err)
+		}
 		if len(logicals) > 0 {
 			mbr.logicalPartitions = append(mbr.logicalPartitions, logicals...)
 		} else {
@@ -253,7 +256,12 @@ func parsePartitionEntry(buf []byte) Partition {
 // Each EBR has the same 512-byte structure as an MBR:
 //   - Entry 0: logical partition (StartSector relative to this EBR)
 //   - Entry 1: next EBR pointer (StartSector relative to extStartSector)
-func parseEBRChain(sr *io.SectionReader, extStartSector uint32) []Partition {
+//
+// I/O failures (seek/read/short read) are returned as errors so the
+// caller can distinguish a malformed/truncated image from a legitimate
+// "no EBR" case (signature mismatch), which terminates the chain
+// without an error and lets the caller apply a fallback.
+func parseEBRChain(sr *io.SectionReader, extStartSector uint32) ([]Partition, error) {
 	var partitions []Partition
 	ebrSector := extStartSector
 	visited := make(map[uint32]bool)
@@ -266,14 +274,12 @@ func parseEBRChain(sr *io.SectionReader, extStartSector uint32) []Partition {
 		visited[ebrSector] = true
 
 		ebrOffset := int64(ebrSector) * Sector
-		_, err := sr.Seek(ebrOffset, 0)
-		if err != nil {
-			break
+		if _, err := sr.Seek(ebrOffset, 0); err != nil {
+			return nil, xerrors.Errorf("failed to seek EBR at sector %d: %w", ebrSector, err)
 		}
 
-		n, err := sr.Read(buf)
-		if err != nil || n != Sector {
-			break
+		if _, err := io.ReadFull(sr, buf); err != nil {
+			return nil, xerrors.Errorf("failed to read EBR at sector %d: %w", ebrSector, err)
 		}
 
 		sig := binary.LittleEndian.Uint16(buf[510:512])
@@ -296,5 +302,5 @@ func parseEBRChain(sr *io.SectionReader, extStartSector uint32) []Partition {
 		ebrSector = extStartSector + entry1.StartSector
 	}
 
-	return partitions
+	return partitions, nil
 }

--- a/mbr/mbr.go
+++ b/mbr/mbr.go
@@ -212,9 +212,11 @@ func NewMasterBootRecord(sr *io.SectionReader) (*MasterBootRecord, error) {
 			mbr.logicalPartitions = append(mbr.logicalPartitions, logicals...)
 		} else {
 			// No valid EBR found; adjust partition to skip past the EBR area.
-			mbr.Partitions[i].StartSector += 2
-			if mbr.Partitions[i].Size >= 2 {
+			if mbr.Partitions[i].Size > 2 {
+				mbr.Partitions[i].StartSector += 2
 				mbr.Partitions[i].Size -= 2
+			} else {
+				mbr.Partitions[i].Size = 0
 			}
 		}
 	}

--- a/mbr/mbr_test.go
+++ b/mbr/mbr_test.go
@@ -224,7 +224,7 @@ func TestMasterBootRecord_Next_ExtendedSingleLogical(t *testing.T) {
 
 	// MBR at sector 0
 	writePartitionEntry(buf[446:], true, 0x83, 2, 4)    // partition 0: primary
-	writePartitionEntry(buf[462:], false, 0x05, 10, 20) // partition 1: extended
+	writePartitionEntry(buf[462:], false, 0x0f, 10, 20) // partition 1: extended (LBA)
 	binary.LittleEndian.PutUint16(buf[510:], 0xAA55)
 
 	// EBR 1 at sector 10
@@ -245,7 +245,7 @@ func TestMasterBootRecord_Next_ExtendedSingleLogical(t *testing.T) {
 		marker byte
 	}{
 		{0, 4, 0xAA},  // primary 0
-		{1, 20, 0x00}, // extended (container)
+		{1, 20, 0x00}, // extended LBA (container)
 		{2, 0, 0x00},  // empty
 		{3, 0, 0x00},  // empty
 		{4, 5, 0xCC},  // logical 4

--- a/mbr/mbr_test.go
+++ b/mbr/mbr_test.go
@@ -209,6 +209,240 @@ func TestMasterBootRecord_Next(t *testing.T) {
 	}
 }
 
+func TestMasterBootRecord_Next_ExtendedSingleLogical(t *testing.T) {
+	// Disk layout:
+	//   Sector 0:    MBR
+	//   Sector 2-5:  Primary partition 0 (Type 0x83, Size 4)
+	//   Sector 10:   EBR 1
+	//   Sector 11-15: Logical partition 4 (Type 0x83, Size 5)
+	diskSize := 30 * 512
+	buf := make([]byte, diskSize)
+
+	// Marker bytes
+	buf[2*512] = 0xAA  // primary partition 0 data
+	buf[11*512] = 0xCC // logical partition 4 data
+
+	// MBR at sector 0
+	writePartitionEntry(buf[446:], true, 0x83, 2, 4)    // partition 0: primary
+	writePartitionEntry(buf[462:], false, 0x05, 10, 20) // partition 1: extended
+	binary.LittleEndian.PutUint16(buf[510:], 0xAA55)
+
+	// EBR 1 at sector 10
+	ebr1 := 10 * 512
+	writePartitionEntry(buf[ebr1+446:], false, 0x83, 1, 5) // entry 0: logical (abs sector=10+1=11)
+	// entry 1: no next EBR (type=0)
+	binary.LittleEndian.PutUint16(buf[ebr1+510:], 0xAA55)
+
+	sr := io.NewSectionReader(newReaderAt(buf), 0, int64(len(buf)))
+	m, err := mbr.NewMasterBootRecord(sr)
+	if err != nil {
+		t.Fatalf("NewMasterBootRecord() unexpected error: %v", err)
+	}
+
+	expected := []struct {
+		index  int
+		size   uint64
+		marker byte
+	}{
+		{0, 4, 0xAA},  // primary 0
+		{1, 20, 0x00}, // extended (container)
+		{2, 0, 0x00},  // empty
+		{3, 0, 0x00},  // empty
+		{4, 5, 0xCC},  // logical 4
+	}
+
+	for i, exp := range expected {
+		p, err := m.Next()
+		if err != nil {
+			t.Fatalf("Next() call %d: unexpected error: %v", i, err)
+		}
+		if p.GetSize() != exp.size {
+			t.Errorf("partition %d: GetSize() = %d, want %d", i, p.GetSize(), exp.size)
+		}
+		if exp.size > 0 && exp.marker != 0x00 {
+			psr := p.GetSectionReader()
+			b := make([]byte, 1)
+			if _, err := psr.Read(b); err != nil {
+				t.Fatalf("partition %d: SectionReader.Read() error: %v", i, err)
+			}
+			if b[0] != exp.marker {
+				t.Errorf("partition %d: first byte = %x, want %x", i, b[0], exp.marker)
+			}
+		}
+	}
+
+	_, err = m.Next()
+	if err != io.EOF {
+		t.Errorf("Next() after all partitions: got %v, want io.EOF", err)
+	}
+}
+
+func TestMasterBootRecord_Next_ExtendedMultipleLogicals(t *testing.T) {
+	// Disk layout:
+	//   Sector 0:     MBR
+	//   Sector 2-5:   Primary partition 0 (Type 0x83, Size 4)
+	//   Sector 10:    EBR 1
+	//   Sector 11-15: Logical partition 4 (Type 0x83, Size 5)
+	//   Sector 20:    EBR 2
+	//   Sector 21-25: Logical partition 5 (Type 0x82, Size 5)
+	diskSize := 50 * 512
+	buf := make([]byte, diskSize)
+
+	// Marker bytes
+	buf[2*512] = 0xAA  // primary 0
+	buf[11*512] = 0xBB // logical 4
+	buf[21*512] = 0xCC // logical 5
+
+	// MBR at sector 0
+	writePartitionEntry(buf[446:], true, 0x83, 2, 4)    // partition 0: primary
+	writePartitionEntry(buf[462:], false, 0x05, 10, 40) // partition 1: extended
+	binary.LittleEndian.PutUint16(buf[510:], 0xAA55)
+
+	// EBR 1 at sector 10
+	ebr1 := 10 * 512
+	writePartitionEntry(buf[ebr1+446:], false, 0x83, 1, 5)   // entry 0: logical (abs=11)
+	writePartitionEntry(buf[ebr1+462:], false, 0x05, 10, 16) // entry 1: next EBR at ext_start+10=20
+	binary.LittleEndian.PutUint16(buf[ebr1+510:], 0xAA55)
+
+	// EBR 2 at sector 20
+	ebr2 := 20 * 512
+	writePartitionEntry(buf[ebr2+446:], false, 0x82, 1, 5) // entry 0: logical (abs=21)
+	// entry 1: no next EBR
+	binary.LittleEndian.PutUint16(buf[ebr2+510:], 0xAA55)
+
+	sr := io.NewSectionReader(newReaderAt(buf), 0, int64(len(buf)))
+	m, err := mbr.NewMasterBootRecord(sr)
+	if err != nil {
+		t.Fatalf("NewMasterBootRecord() unexpected error: %v", err)
+	}
+
+	expected := []struct {
+		index  int
+		typB   byte
+		size   uint64
+		marker byte
+	}{
+		{0, 0x83, 4, 0xAA},  // primary 0
+		{1, 0x05, 40, 0x00}, // extended
+		{2, 0x00, 0, 0x00},  // empty
+		{3, 0x00, 0, 0x00},  // empty
+		{4, 0x83, 5, 0xBB},  // logical 4
+		{5, 0x82, 5, 0xCC},  // logical 5
+	}
+
+	for i, exp := range expected {
+		p, err := m.Next()
+		if err != nil {
+			t.Fatalf("Next() call %d: unexpected error: %v", i, err)
+		}
+		if p.GetSize() != exp.size {
+			t.Errorf("partition %d: GetSize() = %d, want %d", i, p.GetSize(), exp.size)
+		}
+		gotType := p.GetType()
+		if len(gotType) != 1 || gotType[0] != exp.typB {
+			t.Errorf("partition %d: GetType() = %x, want %x", i, gotType, exp.typB)
+		}
+		if exp.size > 0 && exp.marker != 0x00 {
+			psr := p.GetSectionReader()
+			b := make([]byte, 1)
+			if _, err := psr.Read(b); err != nil {
+				t.Fatalf("partition %d: SectionReader.Read() error: %v", i, err)
+			}
+			if b[0] != exp.marker {
+				t.Errorf("partition %d: first byte = %x, want %x", i, b[0], exp.marker)
+			}
+		}
+	}
+
+	_, err = m.Next()
+	if err != io.EOF {
+		t.Errorf("Next() after all partitions: got %v, want io.EOF", err)
+	}
+}
+
+func TestMasterBootRecord_Next_ExtendedInvalidEBR(t *testing.T) {
+	// Extended partition with no valid EBR (invalid signature).
+	// Should fall back to adjusting StartSector +2, Size -2.
+	diskSize := 30 * 512
+	buf := make([]byte, diskSize)
+
+	writePartitionEntry(buf[446:], true, 0x83, 2, 4)    // partition 0: primary
+	writePartitionEntry(buf[462:], false, 0x05, 10, 20) // partition 1: extended
+	binary.LittleEndian.PutUint16(buf[510:], 0xAA55)
+
+	// Sector 10: no valid EBR signature (leave as zeros)
+
+	sr := io.NewSectionReader(newReaderAt(buf), 0, int64(len(buf)))
+	m, err := mbr.NewMasterBootRecord(sr)
+	if err != nil {
+		t.Fatalf("NewMasterBootRecord() unexpected error: %v", err)
+	}
+
+	// Extended partition should have StartSector adjusted to 12, Size to 18
+	expected := []struct {
+		size uint64
+	}{
+		{4},  // primary 0
+		{18}, // extended (adjusted: 20-2)
+		{0},  // empty
+		{0},  // empty
+	}
+
+	for i, exp := range expected {
+		p, err := m.Next()
+		if err != nil {
+			t.Fatalf("Next() call %d: unexpected error: %v", i, err)
+		}
+		if p.GetSize() != exp.size {
+			t.Errorf("partition %d: GetSize() = %d, want %d", i, p.GetSize(), exp.size)
+		}
+	}
+
+	// Only 4 primary partitions, no logical
+	_, err = m.Next()
+	if err != io.EOF {
+		t.Errorf("Next() after all partitions: got %v, want io.EOF", err)
+	}
+}
+
+func TestMasterBootRecord_Next_ExtendedCircularReference(t *testing.T) {
+	// EBR chain with circular reference: EBR 1 points to itself.
+	diskSize := 30 * 512
+	buf := make([]byte, diskSize)
+
+	writePartitionEntry(buf[446:], true, 0x83, 2, 4)    // partition 0: primary
+	writePartitionEntry(buf[462:], false, 0x05, 10, 20) // partition 1: extended
+	binary.LittleEndian.PutUint16(buf[510:], 0xAA55)
+
+	// EBR 1 at sector 10: entry 1 points back to sector 10 (circular)
+	ebr1 := 10 * 512
+	writePartitionEntry(buf[ebr1+446:], false, 0x83, 1, 5)  // entry 0: logical
+	writePartitionEntry(buf[ebr1+462:], false, 0x05, 0, 20) // entry 1: points to ext_start+0=10 (self)
+	binary.LittleEndian.PutUint16(buf[ebr1+510:], 0xAA55)
+
+	sr := io.NewSectionReader(newReaderAt(buf), 0, int64(len(buf)))
+	m, err := mbr.NewMasterBootRecord(sr)
+	if err != nil {
+		t.Fatalf("NewMasterBootRecord() unexpected error: %v", err)
+	}
+
+	// Should get 4 primary + 1 logical (chain stops at circular reference)
+	count := 0
+	for {
+		_, err := m.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Next() unexpected error: %v", err)
+		}
+		count++
+	}
+	if count != 5 {
+		t.Errorf("partition count = %d, want 5 (4 primary + 1 logical)", count)
+	}
+}
+
 func writePartitionEntry(dst []byte, boot bool, typeByte byte, startSector, size uint32) {
 	if boot {
 		dst[0] = 0x80

--- a/mbr/mbr_test.go
+++ b/mbr/mbr_test.go
@@ -240,15 +240,14 @@ func TestMasterBootRecord_Next_ExtendedSingleLogical(t *testing.T) {
 	}
 
 	expected := []struct {
-		index  int
 		size   uint64
 		marker byte
 	}{
-		{0, 4, 0xAA},  // primary 0
-		{1, 20, 0x00}, // extended LBA (container)
-		{2, 0, 0x00},  // empty
-		{3, 0, 0x00},  // empty
-		{4, 5, 0xCC},  // logical 4
+		{4, 0xAA},  // primary 0
+		{20, 0x00}, // extended LBA (container)
+		{0, 0x00},  // empty
+		{0, 0x00},  // empty
+		{5, 0xCC},  // logical 4
 	}
 
 	for i, exp := range expected {
@@ -317,17 +316,16 @@ func TestMasterBootRecord_Next_ExtendedMultipleLogicals(t *testing.T) {
 	}
 
 	expected := []struct {
-		index  int
 		typB   byte
 		size   uint64
 		marker byte
 	}{
-		{0, 0x83, 4, 0xAA},  // primary 0
-		{1, 0x05, 40, 0x00}, // extended
-		{2, 0x00, 0, 0x00},  // empty
-		{3, 0x00, 0, 0x00},  // empty
-		{4, 0x83, 5, 0xBB},  // logical 4
-		{5, 0x82, 5, 0xCC},  // logical 5
+		{0x83, 4, 0xAA},  // primary 0
+		{0x05, 40, 0x00}, // extended
+		{0x00, 0, 0x00},  // empty
+		{0x00, 0, 0x00},  // empty
+		{0x83, 5, 0xBB},  // logical 4
+		{0x82, 5, 0xCC},  // logical 5
 	}
 
 	for i, exp := range expected {


### PR DESCRIPTION
## Summary

- Add `parseEBRChain` to traverse Extended Boot Record chains for extended partitions (Type `0x05`/`0x0f`), returning all logical partitions
- Modify `Next()` to iterate over both primary and logical partitions using index-based traversal
- Add circular reference detection (`visited` map) and chain depth limit (`maxEBRChainDepth = 256`) to prevent infinite loops on malformed disk images
- Add `parsePartitionEntry` for byte-level partition entry parsing used by EBR chain traversal
- Fix potential `uint32` underflow when adjusting partition size for invalid EBRs

## References

- https://en.wikipedia.org/wiki/Extended_boot_record — EBR structure, Entry 0/Entry 1 roles, chain traversal
- https://en.wikipedia.org/wiki/Master_boot_record#PTE — MBR partition table entry structure (EBR uses the same 16-byte format)

## Test plan

- [x] Single logical partition via EBR chain
- [x] Multiple logical partitions via 2-level EBR chain
- [x] Invalid EBR signature fallback (StartSector/Size adjustment)
- [x] Circular EBR reference detection
- [x] Existing tests pass (primary-only MBR, GPT)

---

## 概要

- 拡張パーティション (Type `0x05`/`0x0f`) の Extended Boot Record チェーンを走査し、すべての論理パーティションを返す `parseEBRChain` を追加
- `Next()` をインデックスベースのイテレーションに変更し、プライマリと論理パーティションの両方を返すように修正
- 不正なディスクイメージでの無限ループを防ぐため、循環参照検出 (`visited` マップ) とチェーン深さ制限 (`maxEBRChainDepth = 256`) を追加
- EBR チェーン走査で使用するバイトレベルのパーティションエントリ解析 `parsePartitionEntry` を追加
- 無効な EBR 時のパーティションサイズ調整で `uint32` アンダーフローが発生する可能性を修正

## 参考資料

- https://en.wikipedia.org/wiki/Extended_boot_record — EBR structure, Entry 0/Entry 1 roles, chain traversal
- https://en.wikipedia.org/wiki/Master_boot_record#PTE — MBR partition table entry structure (EBR uses the same 16-byte format)

## テスト計画

- [x] 単一論理パーティション（EBR チェーン1段）
- [x] 複数論理パーティション（EBR チェーン2段）
- [x] 無効な EBR シグネチャ時のフォールバック（StartSector/Size 調整）
- [x] 循環参照検出
- [x] 既存テスト通過（プライマリのみ MBR、GPT）